### PR TITLE
Disabled automated array to memmap conversion

### DIFF
--- a/jwalk/corpus.py
+++ b/jwalk/corpus.py
@@ -56,7 +56,7 @@ def walk_graph(csr_matrix, labels, walk_length=40, num_walks=1, n_jobs=1):
     """
     normalized = normalize_csr_matrix(csr_matrix)
 
-    results = (Parallel(n_jobs=n_jobs)
+    results = (Parallel(n_jobs=n_jobs, max_nbytes=None)
                (delayed(walk_random, has_shareable_memory)
                 (normalized, labels, walk_length)
                 for _ in range(num_walks)))


### PR DESCRIPTION
When the adjacency matrix exceeds 1 megabyte Joblib triggers automatic memory mapping of the csr matrix. Whenever this happens the following ValueError occurs:

```
Traceback (most recent call last):
  File "/Users/rik/JWPlayer/datascience/projects/recs_challenge/venv/lib/python3.6/site-packages/joblib/_parallel_backends.py", line 350, in __call__
    return self.func(*args, **kwargs)
  File "/Users/rik/JWPlayer/datascience/projects/recs_challenge/venv/lib/python3.6/site-packages/joblib/parallel.py", line 131, in __call__
    return [func(*args, **kwargs) for func, args, kwargs in self.items]
  File "/Users/rik/JWPlayer/datascience/projects/recs_challenge/venv/lib/python3.6/site-packages/joblib/parallel.py", line 131, in <listcomp>
    return [func(*args, **kwargs) for func, args, kwargs in self.items]
  File "/Users/rik/JWPlayer/datascience/projects/recs_challenge/venv/lib/python3.6/site-packages/jwalk/corpus.py", line 24, in walk_random
    return walks.walk_random(normalized_csr, labels, walk_length)
  File "jwalk/src/walks.pyx", line 52, in jwalk.walks.walk_random (jwalk/src/walks.c:2435)
  File "stringsource", line 644, in View.MemoryView.memoryview_cwrapper (jwalk/src/walks.c:11147)
  File "stringsource", line 345, in View.MemoryView.memoryview.__cinit__ (jwalk/src/walks.c:7382)
ValueError: buffer source array is read-only
```

This PR works around this error by disabling automatic memory mapping.